### PR TITLE
Obsolete storage table roles

### DIFF
--- a/Microsoft.Storage/storage-table-contributor.json
+++ b/Microsoft.Storage/storage-table-contributor.json
@@ -1,7 +1,7 @@
 {
-    "Name": "Storage Table Contributor (custom)",
+    "Name": "Storage Table Contributor (custom) [Obsolete]",
     "IsCustom": true,
-    "Description": "Grants full access to manage the Storage Table service",
+    "Description": "[Obsolete] Grants full access to manage the Storage Table service",
     "Actions": [
         "Microsoft.Storage/storageAccounts/tableServices/*"
     ],

--- a/Microsoft.Storage/storage-table-contributor.md
+++ b/Microsoft.Storage/storage-table-contributor.md
@@ -1,7 +1,7 @@
 # Storage Table Contributor
 
-[!WARNING]
-This role is Obsolete. Consider migrating to the Azure built-in RBAC role [Storage Table Data Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/storage#storage-table-data-contributor).
+> [!WARNING]
+> This role is Obsolete. Consider migrating to the Azure built-in RBAC role [Storage Table Data Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/storage#storage-table-data-contributor).
 
 This role grants permission to the user to manage the Storage Table service.
 

--- a/Microsoft.Storage/storage-table-contributor.md
+++ b/Microsoft.Storage/storage-table-contributor.md
@@ -1,5 +1,8 @@
 # Storage Table Contributor
 
+[!WARNING]
+This role is Obsolete. Consider migrating to the Azure built-in RBAC role [Storage Table Data Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/storage#storage-table-data-contributor).
+
 This role grants permission to the user to manage the Storage Table service.
 
 All actions can be found in the [documentation](https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations#microsoftstorage).

--- a/Microsoft.Storage/storage-table-data-contributor.json
+++ b/Microsoft.Storage/storage-table-data-contributor.json
@@ -1,7 +1,7 @@
 {
-    "Name": "Storage Table Data Contributor (custom)",
+    "Name": "Storage Table Data Contributor (custom) [Obsolete]",
     "IsCustom": true,
-    "Description": "Read, write, and delete Azure Storage Table tables and data",
+    "Description": "[Obsolete] Read, write, and delete Azure Storage Table tables and data",
     "Actions": [
         "Microsoft.Storage/storageAccounts/tableServices/read",
         "Microsoft.Storage/storageAccounts/tableServices/tables/*"

--- a/Microsoft.Storage/storage-table-data-contributor.md
+++ b/Microsoft.Storage/storage-table-data-contributor.md
@@ -1,5 +1,8 @@
 # Storage Table Data Contributor
 
+[!WARNING]
+This role is Obsolete. Consider migrating to the Azure built-in RBAC role [Storage Table Data Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/storage#storage-table-data-contributor).
+
 This role grants permission to the user to eead, write, and delete Azure Storage Table tables and data.
 
 All actions can be found in the [documentation](https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations#microsoftstorage).

--- a/Microsoft.Storage/storage-table-data-contributor.md
+++ b/Microsoft.Storage/storage-table-data-contributor.md
@@ -1,7 +1,7 @@
 # Storage Table Data Contributor
 
-[!WARNING]
-This role is Obsolete. Consider migrating to the Azure built-in RBAC role [Storage Table Data Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/storage#storage-table-data-contributor).
+> [!WARNING]
+> This role is Obsolete. Consider migrating to the Azure built-in RBAC role [Storage Table Data Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/storage#storage-table-data-contributor).
 
 This role grants permission to the user to eead, write, and delete Azure Storage Table tables and data.
 

--- a/README.md
+++ b/README.md
@@ -11,5 +11,13 @@ Following custom roles are defined in this repository.
 | Power BI Embedded Operator | [powerbi-embedded-operator.json](./Microsoft.PowerBIDedicated/powerbi-embedded-operator.json) | [powerbi-embedded-operator.md](./Microsoft.PowerBIDedicated/powerbi-embedded-operator.md) |
 | Storage Account Key Reader | [account-key-reader.json](./Microsoft.Storage/account-key-reader.json) | [account-key-reader.md](./Microsoft.Storage/account-key-reader.md) |
 | Storage Account Management Policies Contributor | [account-managementpolicies-contributor.json](./Microsoft.Storage/account-managementpolicies-contributor.json) | [account-managementpolicies-contributor.md](./Microsoft.Storage/account-managementpolicies-contributor.md) |
+
+# [Obsolete] Azure Custom Roles
+
+[!WARNING]
+The roles below should be treated Obsolete and superseded by built-in Azure RBAC roles.
+
+| Name | Definition file | Documentation |
+|-|-|-|
 | Storage Table Contributor | [storage-table-contributor.json](./Microsoft.Storage/storage-table-contributor.json) | [storage-table-contributor](./Microsoft.Storage/storage-table-contributor.md) |
 | Storage Table Data Contributor | [storage-table-data-contributor.json](./Microsoft.Storage/storage-table-data-contributor.json) | [storage-table-data-contributor](./Microsoft.Storage/storage-table-data-contributor.md) |

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Following custom roles are defined in this repository.
 
 # [Obsolete] Azure Custom Roles
 
-[!WARNING]
-The roles below should be treated Obsolete and superseded by built-in Azure RBAC roles.
+> [!WARNING]
+> The roles below should be treated Obsolete and superseded by built-in Azure RBAC roles.
 
 | Name | Definition file | Documentation |
 |-|-|-|


### PR DESCRIPTION
Mark the Storage Table custom roles as Obsolete and refer to the Azure documentation to use the built-in RBAC roles.